### PR TITLE
Fix: Correct missing root closing div in checkout.vue

### DIFF
--- a/frontend/pages/checkout.vue
+++ b/frontend/pages/checkout.vue
@@ -137,6 +137,7 @@
     </div> <!-- End of lg:grid -->
     </div> <!-- Closing tag for <div v-else> associated with isLoadingAuthOrCart -->
   </ClientOnly> <!-- End of ClientOnly -->
+  </div> <!-- Closing tag for the root container div -->
 </template>
 
 <script setup>


### PR DESCRIPTION
Resolved 'Element is missing end tag' error in frontend/pages/checkout.vue by adding the missing closing `</div>` tag for the main root container element at the end of the template block. This ensures the overall HTML structure of the page component is well-formed.