### PR TITLE
Attempt to fix product variant options loading

### DIFF
--- a/backend/routes/adminProductSpecificOptions.js
+++ b/backend/routes/adminProductSpecificOptions.js
@@ -73,10 +73,11 @@ router.get(
             pao.option_id,
             po.name AS option_name,
             COALESCE(
-                (SELECT json_agg(json_build_object('id', pov.id, 'value', pov.value ORDER BY pov.value))
+                (SELECT json_agg(json_build_object('id', pov.id, 'value', pov.value))
                  FROM product_assigned_option_specific_values paosv
                  JOIN product_option_values pov ON paosv.product_option_value_id = pov.id
-                 WHERE paosv.product_assigned_option_id = pao.id),
+                 WHERE paosv.product_assigned_option_id = pao.id
+                ),
                 '[]'::json
             ) AS selected_values
         FROM


### PR DESCRIPTION
This commit includes several attempts to modify the SQL query for GET /products/:productId/assigned-options in adminProductSpecificOptions.js. The goal is to correctly fetch `selected_values` for each assigned option so that the ProductVariantsManager on the frontend can function correctly.

The latest version of the query in this commit removes all ORDER BY clauses from the subquery responsible for generating `selected_values`, _as a debugging step to isolate the persistent PostgreSQL error_: "ORDER BY specified, but json_build_object is not an aggregate function".

If this error continues after this commit and a server restart, it indicates that the code changes are not being correctly reflected in the running environment.